### PR TITLE
Fix: missing `TraceType::environment()` implementation

### DIFF
--- a/yactfr/metadata/trace-type.cpp
+++ b/yactfr/metadata/trace-type.cpp
@@ -68,6 +68,11 @@ const boost::optional<boost::uuids::uuid>& TraceType::uuid() const noexcept
     return _pimpl->uuid();
 }
 
+const TraceEnvironment& TraceType::environment() const noexcept
+{
+    return _pimpl->environment();
+}
+
 const StructureType* TraceType::packetHeaderType() const noexcept
 {
     return _pimpl->pktHeaderType();


### PR DESCRIPTION
Signed-off-by: Francis Deslauriers <fdeslaur@gmail.com>