### PR TITLE
Build fix

### DIFF
--- a/yactfr/internal/metadata/str-scanner.hpp
+++ b/yactfr/internal/metadata/str-scanner.hpp
@@ -15,6 +15,7 @@
 #include <limits>
 #include <regex>
 #include <cmath>
+#include <array>
 #include <boost/utility.hpp>
 #include <boost/optional.hpp>
 

--- a/yactfr/metadata/metadata.cpp
+++ b/yactfr/metadata/metadata.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <vector>
 #include <cassert>
+#include <array>
 #include <boost/endian/conversion.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>

--- a/yactfr/mmap-file-view-factory.cpp
+++ b/yactfr/mmap-file-view-factory.cpp
@@ -7,6 +7,7 @@
 
 #include <cstring>
 #include <sstream>
+#include <array>
 #include <sys/mman.h>
 
 #include <yactfr/mmap-file-view-factory.hpp>


### PR DESCRIPTION
As reported in #4, the build currently fails. The failures are caused by a number of missing inclusions of `<array>` resulting in incomplete type errors.