### PR TITLE
Fix build, std int types not found

### DIFF
--- a/yactfr/metadata/metadata.cpp
+++ b/yactfr/metadata/metadata.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <vector>
 #include <cassert>
+#include <cstdint>
 #include <array>
 #include <boost/endian/conversion.hpp>
 #include <boost/uuid/nil_generator.hpp>

--- a/yactfr/mmap-file-view-factory.cpp
+++ b/yactfr/mmap-file-view-factory.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <cstring>
+#include <cstdint>
 #include <sstream>
 #include <array>
 #include <sys/mman.h>


### PR DESCRIPTION
On Arch Linux, with "g++ (GCC) 13.1.1 20230429", I get some errors like:

    /usr/bin/c++ -DZF_LOG_DEF_SRCLOC=ZF_LOG_SRCLOC_NONE -DZF_LOG_LEVEL=ZF_LOG_NONE -Dyactfr_EXPORTS -I/home/simark/src/yactfr/include -std=c++14 -fPIC -MD -MT yactfr/CMakeFiles/yactfr.dir/metadata/metadata.cpp.o -MF yactfr/CMakeFiles/yactfr.dir/metadata/metadata.cpp.o.d -o yactfr/CMakeFiles/yactfr.dir/metadata/metadata.cpp.o -c /home/simark/src/yactfr/yactfr/metadata/metadata.cpp
    /home/simark/src/yactfr/yactfr/metadata/metadata.cpp:80:14: error: ‘uint32_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
       80 |         std::uint32_t magic;

Include cstdint to fix them.